### PR TITLE
S5pro fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cncjs",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "A web-based interface for CNC milling controller running Grbl, Marlin, Smoothieware, or TinyG",
   "homepage": "https://github.com/cncjs/cncjs",
   "author": "Cheton Wu <cheton@gmail.com>",

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -19,7 +19,7 @@ popd
 babel -d dist/cncjs/server src/server
 i18next-scanner --config i18next-scanner.server.config.js \"src/server/**/*.{html,js,jsx}\" \"!src/server/i18n/**\" \"!**/node_modules/**\"
 
-cross-env NODE_ENV=production webpack-cli --config webpack.config.production.js
+cross-env NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider webpack-cli --config webpack.config.production.js
 i18next-scanner --config i18next-scanner.app.config.js \"src/app/**/*.{html,js,jsx}\" \"!src/app/i18n/**\" \"!**/node_modules/**\"
 
 mkdir -p dist/cncjs/app

--- a/src/app/containers/Settings/MachineProfiles/CreateRecord.jsx
+++ b/src/app/containers/Settings/MachineProfiles/CreateRecord.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Form, Field } from 'react-final-form';
 import { Input } from 'app/components/FormControl';
+import { Checkbox } from 'app/components/Checkbox';
 import FormGroup from 'app/components/FormGroup';
 import { FlexContainer, Row, Col } from 'app/components/GridSystem';
 import Margin from 'app/components/Margin';
@@ -22,7 +23,7 @@ class CreateRecord extends Component {
     };
 
     state = this.getInitialState();
-
+    
     getInitialState() {
       return {
         values: {
@@ -34,7 +35,8 @@ class CreateRecord extends Component {
             ymax: 0,
             zmin: 0,
             zmax: 0,
-          }
+          },
+          avoidParens: false
         }
       };
     }
@@ -51,7 +53,8 @@ class CreateRecord extends Component {
           ymax: Number(_get(values, 'limits.ymax')) || 0,
           zmin: Number(_get(values, 'limits.zmin')) || 0,
           zmax: Number(_get(values, 'limits.zmax')) || 0,
-        }
+        },
+        avoidParens: Boolean(_get(values, 'avoidParens', false))
       });
     };
 
@@ -179,6 +182,17 @@ class CreateRecord extends Component {
                     <Margin left={24}>
                       {this.renderLimits()}
                     </Margin>
+                  </SectionGroup>
+                  <SectionGroup>
+                    <Field name="avoidParens" type="checkbox">
+                      {({ input, meta }) => (
+                        <Checkbox
+                          {...input}
+                          >
+                        {i18n._('Don\'t send parentheses to this machine (ONLY for Shapeoko 5 Pro)')}
+                        </Checkbox>
+                     )}
+                    </Field>
                   </SectionGroup>
                 </Modal.Body>
                 <Modal.Footer>

--- a/src/app/containers/Settings/MachineProfiles/CreateRecord.jsx
+++ b/src/app/containers/Settings/MachineProfiles/CreateRecord.jsx
@@ -23,7 +23,7 @@ class CreateRecord extends Component {
     };
 
     state = this.getInitialState();
-    
+
     getInitialState() {
       return {
         values: {
@@ -188,10 +188,10 @@ class CreateRecord extends Component {
                       {({ input, meta }) => (
                         <Checkbox
                           {...input}
-                          >
-                        {i18n._('Don\'t send parentheses to this machine (ONLY for Shapeoko 5 Pro)')}
+                        >
+                          {i18n._('Don\'t send parentheses to this machine (ONLY for Shapeoko 5 Pro)')}
                         </Checkbox>
-                     )}
+                      )}
                     </Field>
                   </SectionGroup>
                 </Modal.Body>

--- a/src/app/containers/Settings/MachineProfiles/UpdateRecord.jsx
+++ b/src/app/containers/Settings/MachineProfiles/UpdateRecord.jsx
@@ -192,10 +192,10 @@ class UpdateRecord extends Component {
                       {({ input, meta }) => (
                         <Checkbox
                           {...input}
-                          >
-                        {i18n._('Don\'t send parentheses to this machine (ONLY for Shapeoko 5 Pro)')}
+                        >
+                          {i18n._('Don\'t send parentheses to this machine (ONLY for Shapeoko 5 Pro)')}
                         </Checkbox>
-                     )}
+                      )}
                     </Field>
                   </SectionGroup>
                 </Modal.Body>

--- a/src/app/containers/Settings/MachineProfiles/UpdateRecord.jsx
+++ b/src/app/containers/Settings/MachineProfiles/UpdateRecord.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Form, Field } from 'react-final-form';
 import { Input } from 'app/components/FormControl';
+import { Checkbox } from 'app/components/Checkbox';
 import FormGroup from 'app/components/FormGroup';
 import { FlexContainer, Row, Col } from 'app/components/GridSystem';
 import Margin from 'app/components/Margin';
@@ -36,7 +37,8 @@ class UpdateRecord extends Component {
             ymax: Number(_get(values, 'limits.ymax')) || 0,
             zmin: Number(_get(values, 'limits.zmin')) || 0,
             zmax: Number(_get(values, 'limits.zmax')) || 0,
-          }
+          },
+          avoidParens: Boolean(_get(values, 'avoidParens', false))
         }
       };
     }
@@ -55,7 +57,8 @@ class UpdateRecord extends Component {
           ymax: Number(_get(values, 'limits.ymax')) || 0,
           zmin: Number(_get(values, 'limits.zmin')) || 0,
           zmax: Number(_get(values, 'limits.zmax')) || 0,
-        }
+        },
+        avoidParens: Boolean(_get(values, 'avoidParens', false))
       }, forceReload);
     };
 
@@ -183,6 +186,17 @@ class UpdateRecord extends Component {
                     <Margin left={24}>
                       {this.renderLimits()}
                     </Margin>
+                  </SectionGroup>
+                  <SectionGroup>
+                    <Field name="avoidParens" type="checkbox">
+                      {({ input, meta }) => (
+                        <Checkbox
+                          {...input}
+                          >
+                        {i18n._('Don\'t send parentheses to this machine (ONLY for Shapeoko 5 Pro)')}
+                        </Checkbox>
+                     )}
+                    </Field>
                   </SectionGroup>
                 </Modal.Body>
                 <Modal.Footer>

--- a/src/app/i18n/cs/resource.json
+++ b/src/app/i18n/cs/resource.json
@@ -537,5 +537,6 @@
     "SET": "NASTAVIT",
     "CLR": "VYMAZAT",
     "Set RTS line status upon opening": "Nastavit stav řádky RTS při otevírání",
-    "Use RTS/CTS flow control": "Použijte řízení toku RTS/CTS"
+    "Use RTS/CTS flow control": "Použijte řízení toku RTS/CTS",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/de/resource.json
+++ b/src/app/i18n/de/resource.json
@@ -537,5 +537,6 @@
     "SET": "SETZEN",
     "CLR": "LÖSCHEN",
     "Set RTS line status upon opening": "Setze den RTS-Leitungsstatus beim Öffnen",
-    "Use RTS/CTS flow control": "Verwende RTS/CTS-Flusskontrolle"
+    "Use RTS/CTS flow control": "Verwende RTS/CTS-Flusskontrolle",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/en/resource.json
+++ b/src/app/i18n/en/resource.json
@@ -537,5 +537,6 @@
     "SET": "SET",
     "CLR": "CLR",
     "Set RTS line status upon opening": "Set RTS line status upon opening",
-    "Use RTS/CTS flow control": "Use RTS/CTS flow control"
+    "Use RTS/CTS flow control": "Use RTS/CTS flow control",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)"
 }

--- a/src/app/i18n/es/resource.json
+++ b/src/app/i18n/es/resource.json
@@ -537,5 +537,6 @@
     "SET": "ESTABLECER",
     "CLR": "BORRAR",
     "Set RTS line status upon opening": "Establecer el estado de la línea RTS al abrir",
-    "Use RTS/CTS flow control": "Utilice control de flujo RTS/CTS"
+    "Use RTS/CTS flow control": "Utilice control de flujo RTS/CTS",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/fr/resource.json
+++ b/src/app/i18n/fr/resource.json
@@ -537,5 +537,6 @@
     "SET": "ÉTABLIR",
     "CLR": "CLR",
     "Set RTS line status upon opening": "Définir l'état de la ligne RTS à l'ouverture",
-    "Use RTS/CTS flow control": "Utilisez le contrôle de flux RTS/CTS"
+    "Use RTS/CTS flow control": "Utilisez le contrôle de flux RTS/CTS",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/hu/resource.json
+++ b/src/app/i18n/hu/resource.json
@@ -537,5 +537,6 @@
     "SET": "BEÁLLÍT",
     "CLR": "TÖRLÉS",
     "Set RTS line status upon opening": "RTS vonal állapotának beállítása az nyitáskor",
-    "Use RTS/CTS flow control": "Használjon RTS/CTS áramvezérlést"
+    "Use RTS/CTS flow control": "Használjon RTS/CTS áramvezérlést",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/it/resource.json
+++ b/src/app/i18n/it/resource.json
@@ -537,5 +537,6 @@
     "SET": "IMPOSTA",
     "CLR": "CANCELLA",
     "Set RTS line status upon opening": "Imposta lo stato della linea RTS all'apertura",
-    "Use RTS/CTS flow control": "Utilizzare il controllo di flusso RTS/CTS"
+    "Use RTS/CTS flow control": "Utilizzare il controllo di flusso RTS/CTS",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/ja/resource.json
+++ b/src/app/i18n/ja/resource.json
@@ -537,5 +537,6 @@
     "SET": "設定",
     "CLR": "クリア",
     "Set RTS line status upon opening": "開くときにRTSラインの状態を設定する",
-    "Use RTS/CTS flow control": "RTS/CTSフロー制御を使用する"
+    "Use RTS/CTS flow control": "RTS/CTSフロー制御を使用する",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/nb/resource.json
+++ b/src/app/i18n/nb/resource.json
@@ -537,5 +537,6 @@
     "SET": "SETT",
     "CLR": "SLETT",
     "Set RTS line status upon opening": "Sett RTS-linjestatus ved åpning",
-    "Use RTS/CTS flow control": "Bruk RTS/CTS strømstyring"
+    "Use RTS/CTS flow control": "Bruk RTS/CTS strømstyring",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/nl/resource.json
+++ b/src/app/i18n/nl/resource.json
@@ -537,5 +537,6 @@
     "SET": "INSTELLEN",
     "CLR": "WISSEN",
     "Set RTS line status upon opening": "Stel RTS-lijnstatus in bij opening",
-    "Use RTS/CTS flow control": "Gebruik RTS/CTS-stroomregeling"
+    "Use RTS/CTS flow control": "Gebruik RTS/CTS-stroomregeling",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/pt-br/resource.json
+++ b/src/app/i18n/pt-br/resource.json
@@ -537,5 +537,6 @@
     "SET": "DEFINIR",
     "CLR": "LIMPAR",
     "Set RTS line status upon opening": "Definir status da linha RTS na abertura",
-    "Use RTS/CTS flow control": "Use o controle de fluxo RTS/CTS"
+    "Use RTS/CTS flow control": "Use o controle de fluxo RTS/CTS",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/pt-pt/resource.json
+++ b/src/app/i18n/pt-pt/resource.json
@@ -537,5 +537,6 @@
     "SET": "DEFINIR",
     "CLR": "LIMPAR",
     "Set RTS line status upon opening": "Definir estado da linha RTS na abertura",
-    "Use RTS/CTS flow control": "Use o controlo de fluxo RTS/CTS"
+    "Use RTS/CTS flow control": "Use o controlo de fluxo RTS/CTS",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/ru/resource.json
+++ b/src/app/i18n/ru/resource.json
@@ -537,5 +537,6 @@
     "SET": "УСТАНОВИТЬ",
     "CLR": "ОЧИСТИТЬ",
     "Set RTS line status upon opening": "Установить статус линии RTS при открытии",
-    "Use RTS/CTS flow control": "Используйте контроль потока RTS/CTS"
+    "Use RTS/CTS flow control": "Используйте контроль потока RTS/CTS",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/tr/resource.json
+++ b/src/app/i18n/tr/resource.json
@@ -537,5 +537,6 @@
     "SET": "AYARLA",
     "CLR": "TEMİZLE",
     "Set RTS line status upon opening": "Açılışta RTS hat durumunu ayarla",
-    "Use RTS/CTS flow control": "RTS/CTS akış kontrolü kullanın"
+    "Use RTS/CTS flow control": "RTS/CTS akış kontrolü kullanın",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/zh-cn/resource.json
+++ b/src/app/i18n/zh-cn/resource.json
@@ -537,5 +537,6 @@
     "SET": "设置",
     "CLR": "清除",
     "Set RTS line status upon opening": "打开时设置RTS线路状态",
-    "Use RTS/CTS flow control": "使用RTS/CTS流控制"
+    "Use RTS/CTS flow control": "使用RTS/CTS流控制",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/i18n/zh-tw/resource.json
+++ b/src/app/i18n/zh-tw/resource.json
@@ -537,5 +537,6 @@
     "SET": "設置",
     "CLR": "清除",
     "Set RTS line status upon opening": "開啟時設置RTS線路狀態",
-    "Use RTS/CTS flow control": "使用RTS/CTS流量控制"
+    "Use RTS/CTS flow control": "使用RTS/CTS流量控制",
+    "Don't send parentheses to this machine (ONLY for Shapeoko 5 Pro)": ""
 }

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -28,6 +28,7 @@ import Notifications from './Notifications';
 import Loading from './Loading';
 import Rendering from './Rendering';
 import WatchDirectory from './WatchDirectory';
+import store from 'app/store';
 import {
   // Units
   IMPERIAL_UNITS,
@@ -245,7 +246,8 @@ class VisualizerWidget extends PureComponent {
           }
         }));
 
-        controller.command('gcode:load', name, gcode, context, (err, data) => {
+        const machine = store.get('workspace.machineProfile');
+        controller.command('gcode:load', name, gcode, machine, context, (err, data) => {
           if (err) {
             this.setState((state) => ({
               gcode: {

--- a/src/app/widgets/Visualizer/index.jsx
+++ b/src/app/widgets/Visualizer/index.jsx
@@ -16,6 +16,7 @@ import controller from 'app/lib/controller';
 import i18n from 'app/lib/i18n';
 import log from 'app/lib/log';
 import portal from 'app/lib/portal';
+import store from 'app/store';
 import * as WebGL from 'app/lib/three/WebGL';
 import { in2mm } from 'app/lib/units';
 import WidgetConfig from '../WidgetConfig';
@@ -28,7 +29,6 @@ import Notifications from './Notifications';
 import Loading from './Loading';
 import Rendering from './Rendering';
 import WatchDirectory from './WatchDirectory';
-import store from 'app/store';
 import {
   // Units
   IMPERIAL_UNITS,

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cncjs-app",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "productName": "CNCjs",
   "description": "CNC Milling Controller",
   "homepage": "https://github.com/cncjs/cncjs",

--- a/src/server/api/api.machines.js
+++ b/src/server/api/api.machines.js
@@ -5,7 +5,7 @@ import _castArray from 'lodash/castArray';
 import _isPlainObject from 'lodash/isPlainObject';
 import uuid from 'uuid';
 import settings from '../config/settings';
-import { ensureNumber, ensureString } from '../lib/ensure-type';
+import { ensureNumber, ensureString, ensureBoolean } from '../lib/ensure-type';
 import logger from '../lib/logger';
 import config from '../services/configstore';
 import { getPagingRange } from './paging';
@@ -19,6 +19,7 @@ const log = logger('api:machines');
 const CONFIG_KEY = 'machines';
 
 const getSanitizedRecords = () => {
+
   const records = _castArray(config.get(CONFIG_KEY, []));
 
   let shouldUpdate = false;
@@ -46,7 +47,7 @@ const getSanitizedRecords = () => {
 };
 
 const ensureMachineProfile = (payload) => {
-  const { id, name, limits } = { ...payload };
+  const { id, name, limits, avoidParens } = { ...payload };
   const { xmin = 0, xmax = 0, ymin = 0, ymax = 0, zmin = 0, zmax = 0 } = { ...limits };
 
   return {
@@ -59,7 +60,8 @@ const ensureMachineProfile = (payload) => {
       ymax: ensureNumber(ymax) || 0,
       zmin: ensureNumber(zmin) || 0,
       zmax: ensureNumber(zmax) || 0,
-    }
+    },
+    avoidParens: ensureBoolean(avoidParens)
   };
 };
 
@@ -149,6 +151,7 @@ export const update = (req, res) => {
       ['limits.ymax', ensureNumber],
       ['limits.zmin', ensureNumber],
       ['limits.zmax', ensureNumber],
+      ['avoidParens', ensureBoolean],
     ].forEach(it => {
       const [key, ensureType] = it;
       const defaultValue = _get(record, key);

--- a/src/server/api/api.machines.js
+++ b/src/server/api/api.machines.js
@@ -19,7 +19,6 @@ const log = logger('api:machines');
 const CONFIG_KEY = 'machines';
 
 const getSanitizedRecords = () => {
-
   const records = _castArray(config.get(CONFIG_KEY, []));
 
   let shouldUpdate = false;

--- a/src/server/controllers/Marlin/MarlinController.js
+++ b/src/server/controllers/Marlin/MarlinController.js
@@ -1109,7 +1109,7 @@ class MarlinController {
           // be no queued motions, as long as no more commands were sent after the G4.
           // This is the fastest way to do it without having to check the status reports.
           const dwell = '%wait ; Wait for the planner to empty';
-          const ok = this.sender.load(name, gcode + '\n' + dwell, context);
+          const ok = this.sender.load(name, gcode + '\n' + dwell, null, context);
           if (!ok) {
             callback(new Error(`Invalid G-code: name=${name}`));
             return;

--- a/src/server/controllers/Smoothie/SmoothieController.js
+++ b/src/server/controllers/Smoothie/SmoothieController.js
@@ -1023,7 +1023,7 @@ class SmoothieController {
           // be no queued motions, as long as no more commands were sent after the G4.
           // This is the fastest way to do it without having to check the status reports.
           const dwell = '%wait ; Wait for the planner to empty';
-          const ok = this.sender.load(name, gcode + '\n' + dwell, context);
+          const ok = this.sender.load(name, gcode + '\n' + dwell, null, context);
           if (!ok) {
             callback(new Error(`Invalid G-code: name=${name}`));
             return;

--- a/src/server/controllers/TinyG/TinyGController.js
+++ b/src/server/controllers/TinyG/TinyGController.js
@@ -1123,7 +1123,7 @@ class TinyGController {
           // be no queued motions, as long as no more commands were sent after the G4.
           // This is the fastest way to do it without having to check the status reports.
           const dwell = '%wait ; Wait for the planner to empty';
-          const ok = this.sender.load(name, gcode + '\n' + dwell, context);
+          const ok = this.sender.load(name, gcode + '\n' + dwell, null, context);
           if (!ok) {
             callback(new Error(`Invalid G-code: name=${name}`));
             return;

--- a/src/server/lib/Sender.js
+++ b/src/server/lib/Sender.js
@@ -261,7 +261,7 @@ class Sender extends events.EventEmitter {
     }
 
     // @return {boolean} Returns true on success, false otherwise.
-    load(name, gcode = '', context = {}) {
+    load(name, gcode = '', machine, context = {}) {
       if (typeof gcode !== 'string' || !gcode) {
         return false;
       }
@@ -272,10 +272,12 @@ class Sender extends events.EventEmitter {
       if (this.sp) {
         this.sp.clear();
       }
+
       this.state.hold = false;
       this.state.holdReason = null;
       this.state.name = name;
       this.state.gcode = gcode;
+      this.state.machine = machine;
       this.state.context = context;
       this.state.lines = lines;
       this.state.total = this.state.lines.length;
@@ -286,7 +288,7 @@ class Sender extends events.EventEmitter {
       this.state.elapsedTime = 0;
       this.state.remainingTime = 0;
 
-      this.emit('load', name, gcode, context);
+      this.emit('load', name, gcode, machine, context);
       this.emit('change');
 
       return true;

--- a/test/sender.js
+++ b/test/sender.js
@@ -30,7 +30,7 @@ test('send-response streaming protocol', (t) => {
   };
 
   const machine = {
-    name: "test",
+    name: 'test',
     limits: {
       xmin: 1,
       xmax: 2,
@@ -174,7 +174,7 @@ test('character-counting streaming protocol', (t) => {
   };
 
   const machine = {
-    name: "test",
+    name: 'test',
     limits: {
       xmin: 1,
       xmax: 2,

--- a/test/sender.js
+++ b/test/sender.js
@@ -13,6 +13,7 @@ test('null streaming protocol', (t) => {
   t.end();
 });
 
+
 test('send-response streaming protocol', (t) => {
   const sender = new Sender(SP_TYPE_SEND_RESPONSE);
   t.equal(sender.sp.type, SP_TYPE_SEND_RESPONSE, 'send-response streaming protocol');
@@ -27,7 +28,21 @@ test('send-response streaming protocol', (t) => {
     zmin: -2,
     zmax: 50
   };
-  const ok = sender.load(path.basename(file), content, context);
+
+  const machine = {
+    name: "test",
+    limits: {
+      xmin: 1,
+      xmax: 2,
+      ymin: 3,
+      ymax: 4,
+      zmin: 5,
+      zmax: 6,
+    },
+    avoidParens: true
+  };
+
+  const ok = sender.load(path.basename(file), content, machine, context);
   t.equal(ok, true, `Failed to load "${file}".`);
 
   t.same(sender.toJSON(), {
@@ -75,6 +90,7 @@ test('send-response streaming protocol', (t) => {
       name: '',
       hold: false,
       holdReason: null,
+      machine: machine,
       context: {},
       gcode: '',
       lines: [],
@@ -124,6 +140,7 @@ test('send-response streaming protocol', (t) => {
   }, 0);
 });
 
+
 test('character-counting streaming protocol', (t) => {
   const sender = new Sender(SP_TYPE_CHAR_COUNTING, {
     bufferSize: 256
@@ -155,7 +172,21 @@ test('character-counting streaming protocol', (t) => {
     zmin: -2,
     zmax: 50
   };
-  const ok = sender.load(path.basename(file), content, context);
+
+  const machine = {
+    name: "test",
+    limits: {
+      xmin: 1,
+      xmax: 2,
+      ymin: 3,
+      ymax: 4,
+      zmin: 5,
+      zmax: 6,
+    },
+    avoidParens: true
+  };
+
+  const ok = sender.load(path.basename(file), content, machine, context);
   t.equal(ok, true, `Failed to load "${file}".`);
 
   t.same(sender.toJSON(), {
@@ -204,6 +235,7 @@ test('character-counting streaming protocol', (t) => {
       holdReason: null,
       name: '',
       gcode: '',
+      machine: machine,
       context: {},
       lines: [],
       total: 0,


### PR DESCRIPTION
The Shapeoko 5 Pro firmware locks up when it encounters a parentheses comment in the gcode. For example:

T1 (select tool 1)
The Carbide 3d team plans to fix this, but until then, manual edits to the gcode are necessary to remove comments left by Fusion 360, VCarve Pro, etc.

This fix adds a checkbox to the machine profiles to avoid sending parentheses to the controller. When that machine is selected and gcode is uploaded to the server, it will modify the gcode on the fly to remove any parentheses comments.